### PR TITLE
fix(cmd): Correctly display version in --help

### DIFF
--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -79,7 +79,7 @@ func main() {
 
 	app := &cli.App{
 		Name:    "src-fingerprint",
-		Version: "unknown",
+		Version: version,
 		Usage:   "Collect user/organization file hashes from your vcs provider of choice",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{


### PR DESCRIPTION
Minor change to correctly display the version when running `src-fingerprint --help`.

With the last release the output is:
```
NAME:
   src-fingerprint - Collect user/organization file hashes from your vcs provider of choice

USAGE:
   src-fingerprint [global options] command [command options] [arguments...]

VERSION:
   unknown

[...]
```

With this diff the output becomes:
```
NAME:
   src-fingerprint - Collect user/organization file hashes from your vcs provider of choice

USAGE:
   src-fingerprint [global options] command [command options] [arguments...]

VERSION:
   dev

[...]
```