### PR TITLE
Add a CI step with goreleaser to push a brew formula to gitguardian's tap

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -24,4 +24,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAT_GITHUB: ${{ secrets.PAT_GITHUB }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,3 +30,19 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+
+brews:
+  -
+    name: src-fingerprint
+    tap:
+      owner: gitguardian
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.PAT_GITHUB }}"
+    download_strategy: CurlDownloadStrategy
+    commit_author:
+      name: goreleaserbot
+      email: goreleaser@gitguardian.com
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    folder: Formula
+    description: "src-fingerprint is a CLI util to easily compute the fileshas associated to a set of git repositories."


### PR DESCRIPTION
In this MR, we add a goreleaser CI step to create a brew formula and push it to GitGuardian's tap.  

This behavior was tested [here](https://github.com/pierrelalanne/my-src-fingerprint/actions/runs/1502878053).   

My only concern is whether the `GITHUB_TOKEN` associated by default to the repo will have enough rights to push to `GitGuardian/homebrew-tap`, from what I read, it should be ok. Otherwise we'd have to push a fix to use another token, and add the token to the repo secrets.