### PR TITLE
Improve output generation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,16 @@ on:
     branches: [main]
 
 jobs:
+  golangci:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.43
   build:
     name: Build & Test
     runs-on: ubuntu-latest
@@ -22,12 +32,6 @@ jobs:
 
       - name: Build
         run: go build -v .
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.41
 
       - name: Test
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,12 +36,14 @@ linters:
     - wrapcheck
     - exhaustivestruct
     - errorlint
+    - ireturn
     # temporary disables
     - gci
     - gocritic
     - gofumpt
     - funlen
     - gocyclo
+    - varnamelen
   disable-all: false
   presets:
     - bugs

--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"srcfingerprint"
 	"srcfingerprint/cloner"
 	"srcfingerprint/exporter"
@@ -167,6 +168,7 @@ func mainAction(c *cli.Context) error {
 	}
 
 	output := os.Stdout
+	fsOutput := false
 
 	if c.String("output") != "-" {
 		changedOutput, err := os.OpenFile(c.String("output"), os.O_RDWR|os.O_CREATE, os.ModePerm)
@@ -175,6 +177,7 @@ func mainAction(c *cli.Context) error {
 		}
 
 		output = changedOutput
+		fsOutput = true
 
 		defer output.Close()
 	}
@@ -282,5 +285,11 @@ loop:
 	}
 
 	log.Infoln("Done")
+
+	if fsOutput {
+		path, _ := filepath.Abs(c.String("output"))
+		fmt.Printf("Collected file hashes saved in file %s\n", path) // nolint
+	}
+
 	return nil
 }

--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -111,9 +111,10 @@ func main() {
 				Usage:   "set output path to `FILE`. stdout by default",
 			},
 			&cli.StringFlag{
-				Name:  "export-format",
-				Value: "jsonl",
-				Usage: "export format: 'jsonl'/'gzip-jsonl'/'json'/'gzip-json'. 'jsonl' by default",
+				Name:    "export-format",
+				Aliases: []string{"f"},
+				Value:   "jsonl",
+				Usage:   "export format: 'jsonl'/'gzip-jsonl'/'json'/'gzip-json'. 'jsonl' by default",
 			},
 			&cli.StringFlag{
 				Name:  "clone-dir",

--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -47,12 +47,16 @@ func getProvider(providerStr string, token string, providerOptions provider.Opti
 	}
 }
 
-func getExporter(exporterStr string, output io.Writer) (exporter.Exporter, error) {
+func getExporter(exporterStr string, output io.WriteCloser) (exporter.Exporter, error) {
 	switch exporterStr {
 	case "json":
 		return exporter.NewJSONExporter(output), nil
+	case "gzip-json":
+		return exporter.NewGzipJSONExporter(output), nil
 	case "jsonl":
 		return exporter.NewJSONLExporter(output), nil
+	case "gzip-jsonl":
+		return exporter.NewGzipJSONLExporter(output), nil
 	default:
 		return nil, fmt.Errorf("invalid export format: %s", exporterStr)
 	}
@@ -106,6 +110,11 @@ func main() {
 				Usage:   "set output path to `FILE`. stdout by default",
 			},
 			&cli.StringFlag{
+				Name:  "export-format",
+				Value: "jsonl",
+				Usage: "export format: 'jsonl'/'gzip-jsonl'/'json'/'gzip-json'. 'jsonl' by default",
+			},
+			&cli.StringFlag{
 				Name:  "clone-dir",
 				Value: "-",
 				Usage: "set cloning location for repositories",
@@ -120,11 +129,6 @@ func main() {
 				Aliases:  []string{"p"},
 				Required: true,
 				Usage:    "vcs provider. options: 'gitlab'/'github'/'bitbucket'/'repository'",
-			},
-			&cli.StringFlag{
-				Name:  "export-format",
-				Value: "jsonl",
-				Usage: "export format: 'jsonl'/'json'. jsonl by default",
 			},
 			&cli.StringFlag{
 				Name:    "token",
@@ -278,6 +282,5 @@ loop:
 	}
 
 	log.Infoln("Done")
-
 	return nil
 }

--- a/exporter/output.go
+++ b/exporter/output.go
@@ -32,8 +32,9 @@ func NewJSONExporter(output io.WriteCloser) Exporter {
 	}
 }
 
-func NewGzipJSONExporter(output io.WriteCloser) Exporter {
+func NewGzipJSONExporter(output io.Writer) Exporter {
 	compressedWriter := gzip.NewWriter(output)
+
 	return &JSONExporter{
 		elements: []*ExportGitFile{},
 		encoder:  json.NewEncoder(compressedWriter),
@@ -51,9 +52,11 @@ func (e *JSONExporter) Close() error {
 	if err1 := e.encoder.Encode(e.elements); err1 != nil {
 		return err1
 	}
+
 	if err2 := e.writer.Close(); err2 != nil {
 		return err2
 	}
+
 	return nil
 }
 
@@ -69,8 +72,9 @@ func NewJSONLExporter(output io.WriteCloser) Exporter {
 	}
 }
 
-func NewGzipJSONLExporter(output io.WriteCloser) Exporter {
+func NewGzipJSONLExporter(output io.Writer) Exporter {
 	compressedWriter := gzip.NewWriter(output)
+
 	return &JSONLExporter{
 		encoder: json.NewEncoder(compressedWriter),
 		writer:  compressedWriter,

--- a/exporter/output.go
+++ b/exporter/output.go
@@ -28,7 +28,7 @@ func NewJSONExporter(output io.WriteCloser) Exporter {
 	return &JSONExporter{
 		elements: []*ExportGitFile{},
 		encoder:  json.NewEncoder(output),
-		writer: output,
+		writer:   output,
 	}
 }
 


### PR DESCRIPTION
closes #13 

In this PR:
- two new output formats are implemented: `gzip-jsonl` and `gzip-json` (`gzip-jsonl` becomes the new default format)
- when the output is a file, its path is printed to the stout at the end
- better handle (unlikely) errors when closing the output file