### PR TITLE
chore(ci): fix broken goreleaser CI

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -24,4 +24,5 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
           PAT_GITHUB: ${{ secrets.PAT_GITHUB }}


### PR DESCRIPTION
In this PR, we intend to fix an error we had when running the goreleaser CI step.  

See this [error logs](https://github.com/GitGuardian/src-fingerprint/runs/4410401195?check_suite_focus=true).  