### PR TITLE
feat(cli): Add argument to limit the number of repositories analyzed

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,6 +44,7 @@ linters:
     - funlen
     - gocyclo
     - varnamelen
+    - ifshort # bug: https://github.com/esimonov/ifshort/issues/23
   disable-all: false
   presets:
     - bugs

--- a/extractor.go
+++ b/extractor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -72,9 +73,13 @@ func (fe *FastExtractor) Run(path string, after string) chan *GitFile {
 
 			var gitFile GitFile
 
-			err := json.Unmarshal(line, &gitFile)
+			// Replace backslashes by escaped backslashes
+			re := regexp.MustCompile(`\\\\(.)`)
+			cleanedLine := re.ReplaceAll(line, []byte("\\\\$1"))
+
+			err := json.Unmarshal(cleanedLine, &gitFile)
 			if err != nil {
-				log.Warnln(err)
+				log.Warnln("Error while parsing", string(line), err)
 			}
 
 			fe.ChanGitFiles <- &gitFile


### PR DESCRIPTION
closes #14 

This PR adds an argument `limit` to limit the number of repositories analyzed. When the limit is reached, a warning appears with the number of ignored repositories. The default value of limit is 100 and 0 means no-limit.

Here's an example without verbose:
```
▶ go run cmd/src-fingerprint/main.go -p github -u GitGuardian -o /tmp/sha.jsonl --limit 2 
WARN[0000] Limit reached of repositories! 7 repositories ignored 
Collected file hashes saved in file /tmp/sha.jsonl
```
And with verbose:
```
▶ go run cmd/src-fingerprint/main.go -p github -u GitGuardian  -o /tmp/sha.jsonl --limit 2 -v
INFO[0000] Extracting user GitGuardian                  
INFO[0000] Gathering page 1/? for GitGuardian           
WARN[0000] Limit reached of repositories! 7 repositories ignored 
INFO[0000] Done gathering repositories                  
INFO[0000] Cloning repo py-gitguardian                  
INFO[0000] Cloning repo APISecurityBestPractices        
INFO[0001] Cloned repo py-gitguardian (size: 276 KB)    
INFO[0001] Extracting commits from path /Users/sguillaume/Library/Caches/srcfingerprint/srcfingerprint-4093297460 
INFO[0001] finished reading all files from stdout from git 
INFO[0001] finishing iterating over files, we have collected 211 files 
INFO[0001] Done extracting py-gitguardian               
INFO[0001] Cloned repo APISecurityBestPractices (size: 581 KB) 
INFO[0001] Extracting commits from path /Users/sguillaume/Library/Caches/srcfingerprint/srcfingerprint-2130361511 
INFO[0001] finished reading all files from stdout from git 
INFO[0001] finishing iterating over files, we have collected 70 files 
INFO[0001] Done extracting APISecurityBestPractices     
INFO[0001] Done extracting user GitGuardian             
INFO[0001] Final stats:                                 
INFO[0001] 2/9 repos: 281 files analyzed                
INFO[0001] Dumping to output /tmp/sha.jsonl             
INFO[0001] Done                                         
Collected file hashes saved in file /tmp/sha.jsonl
```