### PR TITLE
feat(provider): fix gitlab flow

### DIFF
--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -23,7 +23,7 @@ const MaxPipelineEvents = 100
 
 func runExtract(
 	pipeline *srcfingerprint.Pipeline,
-	user string,
+	object string,
 	after string,
 	limit int) chan srcfingerprint.PipelineEvent {
 	// buffer it a bit so it won't block if this is going too fast
@@ -31,7 +31,7 @@ func runExtract(
 
 	go func(eventChannel chan srcfingerprint.PipelineEvent) {
 		defer close(eventChannel)
-		pipeline.ExtractRepositories(user, after, eventChannel, limit)
+		pipeline.ExtractRepositories(object, after, eventChannel, limit)
 	}(ch)
 
 	return ch


### PR DESCRIPTION
## What we did
In this MR, we fixed the GitLab flow for `src-fingerprint`.  
Before this fix : the lookup of all accessible repos to a user would have returned all repos accessible including all available public repos, this resulted in a long list of repos to fetch. Also the group lookup was broken because the value to lookup was the group "id" and not the group name.  

To fix this, we :
- Added a [membership option](https://docs.gitlab.com/ee/api/projects.html#list-all-projects) to restrict the list of projects/
- Changed a condition when looking up group to use both the group name or its "path" (see these available [attributes](https://pkg.go.dev/github.com/xanzy/go-gitlab#Group)). This is to handle both behaviors for GitLab enterprise and public.

Also, for clarity :
- We renamed "user" to object, as this argument is not necessarily a user.
- We changed some logs to avoid duplicate lines and clarify some sentences.

## Remarks