### PR TITLE
feat(provider): add information when using the provider repository

### DIFF
--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -138,6 +138,15 @@ func main() {
 				Usage:    "vcs provider. options: 'gitlab'/'github'/'bitbucket'/'repository'",
 			},
 			&cli.StringFlag{
+				Name:  "repo-name",
+				Usage: "Name of the repository to display in outputs if the provider is 'repository'",
+			},
+			&cli.BoolFlag{
+				Name:  "repo-is-private",
+				Value: false,
+				Usage: "Private status value to display in outputs if the provider is 'repository'",
+			},
+			&cli.StringFlag{
 				Name:    "token",
 				Aliases: []string{"t"},
 				Usage:   "token for vcs access.",
@@ -204,9 +213,11 @@ func mainAction(c *cli.Context) error {
 	var srcCloner cloner.Cloner = cloner.NewDiskCloner(c.String("clone-dir"))
 
 	providerOptions := provider.Options{
-		OmitForks:    !c.Bool("extract-forks"),
-		SkipArchived: c.Bool("skip-archived"),
-		BaseURL:      c.String("provider-url"),
+		OmitForks:            !c.Bool("extract-forks"),
+		SkipArchived:         c.Bool("skip-archived"),
+		BaseURL:              c.String("provider-url"),
+		RepositoryName:       c.String("repo-name"),
+		RespositoryIsPrivate: c.Bool("repo-is-private"),
 	}
 
 	defer func() {

--- a/provider/generic_repository.go
+++ b/provider/generic_repository.go
@@ -35,10 +35,11 @@ func (r *Repository) GetStorageSize() int64 { return r.storageSize }
 func (r *Repository) GetPrivate() bool { return r.private }
 
 type GenericProvider struct {
+	options Options
 }
 
 func NewGenericProvider(options Options) Provider {
-	return &GenericProvider{}
+	return &GenericProvider{options}
 }
 
 func (p *GenericProvider) Gather(user string) ([]GitRepository, error) {
@@ -47,11 +48,11 @@ func (p *GenericProvider) Gather(user string) ([]GitRepository, error) {
 	}
 
 	return []GitRepository{&Repository{
-		name:        "",
+		name:        p.options.RepositoryName,
 		httpURL:     user,
 		createdAt:   time.Time{},
 		storageSize: 0,
-		private:     true,
+		private:     p.options.RespositoryIsPrivate,
 	}}, nil
 }
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -42,6 +42,10 @@ type Options struct {
 	OmitForks bool
 	// SkipArchived will skip archived repositories
 	SkipArchived bool
+	// Repository private status to display in the output if the provider is 'repository'
+	RespositoryIsPrivate bool
 	// BaseURL is the base URL of the API
 	BaseURL string
+	// Repository name to display in the output if the provider is 'repository'
+	RepositoryName string
 }


### PR DESCRIPTION
When using the provider 'repository' we add options to precise a
repo-name and whether the repo is private or not in the final outputs.  

This is in order to avoid `jsonl` outputs where the repository_name is not filled, and the private field is inconsistent.