### PR TITLE
feat(github): By default, only gather hashes from private repositories

### DIFF
--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -140,7 +140,7 @@ func main() {
 			&cli.BoolFlag{
 				Name:  "all",
 				Value: false,
-				Usage: "Collect hashes from every accessible repository, not just private repositories if the provider is 'github'",
+				Usage: "Collect fileshas from every accessible repository including public ones if the provider is 'github'",
 			},
 			&cli.StringFlag{
 				Name:  "repo-name",

--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -137,6 +137,11 @@ func main() {
 				Required: true,
 				Usage:    "vcs provider. options: 'gitlab'/'github'/'bitbucket'/'repository'",
 			},
+			&cli.BoolFlag{
+				Name:  "all",
+				Value: false,
+				Usage: "Collect hashes from every accessible repository, not just private repositories if the provider is 'github'",
+			},
 			&cli.StringFlag{
 				Name:  "repo-name",
 				Usage: "Name of the repository to display in outputs if the provider is 'repository'",
@@ -216,6 +221,7 @@ func mainAction(c *cli.Context) error {
 		OmitForks:            !c.Bool("extract-forks"),
 		SkipArchived:         c.Bool("skip-archived"),
 		BaseURL:              c.String("provider-url"),
+		AllRepositories:      c.Bool("all"),
 		RepositoryName:       c.String("repo-name"),
 		RespositoryIsPrivate: c.Bool("repo-is-private"),
 	}

--- a/provider/github.go
+++ b/provider/github.go
@@ -90,7 +90,7 @@ func (p *GitHubProvider) gatherPage(user string, page int) ([]GitRepository, err
 	if p.isOrg {
 		opt := &github.RepositoryListByOrgOptions{
 			ListOptions: github.ListOptions{
-				PerPage: reposPerPage, Page: 1,
+				PerPage: reposPerPage, Page: page,
 			},
 			Type: visibility,
 		}
@@ -104,7 +104,7 @@ func (p *GitHubProvider) gatherPage(user string, page int) ([]GitRepository, err
 	if !p.isOrg {
 		opt := &github.RepositoryListOptions{
 			ListOptions: github.ListOptions{
-				PerPage: reposPerPage, Page: 1,
+				PerPage: reposPerPage, Page: page,
 			},
 			Visibility: visibility,
 		}

--- a/provider/github.go
+++ b/provider/github.go
@@ -78,13 +78,21 @@ func (p *GitHubProvider) gatherPage(user string, page int) ([]GitRepository, err
 		resp       *github.Response
 		repos      []*github.Repository
 		collectErr error
+		visibility string
 	)
+
+	if p.options.AllRepositories {
+		visibility = "all"
+	} else {
+		visibility = "private"
+	}
 
 	if p.isOrg {
 		opt := &github.RepositoryListByOrgOptions{
 			ListOptions: github.ListOptions{
 				PerPage: reposPerPage, Page: 1,
 			},
+			Type: visibility,
 		}
 		repos, resp, collectErr = p.client.Repositories.ListByOrg(context.Background(), user, opt)
 
@@ -98,6 +106,7 @@ func (p *GitHubProvider) gatherPage(user string, page int) ([]GitRepository, err
 			ListOptions: github.ListOptions{
 				PerPage: reposPerPage, Page: 1,
 			},
+			Visibility: visibility,
 		}
 
 		repos, resp, collectErr = p.client.Repositories.List(context.Background(), user, opt)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -44,8 +44,8 @@ type Options struct {
 	SkipArchived bool
 	// Repository private status to display in the output if the provider is 'repository'
 	RespositoryIsPrivate bool
-	// AllRepositories collect hashes from every accessible repository,
-	// not just private repositories if the provider is 'github'
+	// AllRepositories collects fileshas from every accessible repository
+	// including public ones. This is only used by "github" provider
 	AllRepositories bool
 	// BaseURL is the base URL of the API
 	BaseURL string

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -44,6 +44,9 @@ type Options struct {
 	SkipArchived bool
 	// Repository private status to display in the output if the provider is 'repository'
 	RespositoryIsPrivate bool
+	// AllRepositories collect hashes from every accessible repository,
+	// not just private repositories if the provider is 'github'
+	AllRepositories bool
 	// BaseURL is the base URL of the API
 	BaseURL string
 	// Repository name to display in the output if the provider is 'repository'


### PR DESCRIPTION
closes #23 

This PR only changes the behavior of the GitHub provider. By default, it will only gather hashes from private repositories and the added flag `--all` can be used to gather hashes from every repository.

I've also included a fix for the GitHub provider. If there is more than 100 repositories, `src-fingerprint` will only query the first 100 repos and duplicate them. (Always querying the first page of 100 repositories)