### PR TITLE
feat(goreleaser): generate rpm and deb during releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,16 +10,29 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
     main: ./cmd/src-fingerprint
     # Default build flags is `-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`.
+
+nfpms:
+  - formats:
+      - deb
+      - rpm
+    dependencies:
+      - git
+    bindir: /usr/bin
+    vendor: GitGuardian
+    maintainer: GitGuardian <dev@gitguardian.com>
+    replacements:
+      linux: Linux
 
 archives:
   - replacements:
       darwin: Darwin
       linux: Linux
       windows: Windows
-      386: i386
-      amd64: x86_64
 checksum:
   name_template: "checksums.txt"
 snapshot:
@@ -32,8 +45,7 @@ changelog:
       - "^test:"
 
 brews:
-  -
-    name: src-fingerprint
+  - name: src-fingerprint
     tap:
       owner: gitguardian
       name: homebrew-tap


### PR DESCRIPTION
In this MR, we leverage `nfpm` option of goreleaser to support rpm and deb packaging. Read this [documentation](https://goreleaser.com/customization/nfpm/) for some more details.  

**Note :** We also get rid of support for 32 bit architectures which did not make much sense.

Here are the archives we will finally have in a release :  
```shell
src-fingerprint_0.12.0_Darwin_amd64.tar.gz
src-fingerprint_0.12.0_Darwin_arm64.tar.gz
src-fingerprint_0.12.0_Linux_amd64.deb
src-fingerprint_0.12.0_Linux_amd64.rpm
src-fingerprint_0.12.0_Linux_amd64.tar.gz
src-fingerprint_0.12.0_Linux_arm64.deb
src-fingerprint_0.12.0_Linux_arm64.rpm
src-fingerprint_0.12.0_Linux_arm64.tar.gz
src-fingerprint_0.12.0_Windows_amd64.tar.gz
src-fingerprint_0.12.0_Windows_arm64.tar.gz
``` 
Note that although the `*Linux_amd64.deb` could be renamed to `*amd64.deb`, this was not directly available in goreleaser options, that's why we kept it as is.