### PR TITLE
Improve packaging

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,8 +25,16 @@ nfpms:
     bindir: /usr/bin
     vendor: GitGuardian
     maintainer: GitGuardian <dev@gitguardian.com>
+    license: MIT
+    homepage: https://github.com/GitGuardian/src-fingerprint
+    description: "Extract git related information (file shas, commit shas) from your version control system."
     replacements:
       linux: Linux
+    contents:
+      - src: README.md
+        dst: /usr/share/doc/src-fingerprint/README.md
+      - src: LICENSE
+        dst: /usr/share/doc/src-fingerprint/LICENSE
 
 archives:
   - replacements:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,10 @@ archives:
       darwin: Darwin
       linux: Linux
       windows: Windows
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,3 +77,10 @@ What we have done for now to improve performance:
 
 Using go-git resulted in in-memory cloning (stream to memory and then to directory).
 This caused too high peaks of memory unsuitable for small VMs.
+
+## Packaging
+
+Packaging is done using [GoReleaser](https://goreleaser.com/) and
+[nFPM](https://nfpm.goreleaser.com/).
+
+You can test packaging using `make dist`.

--- a/Makefile
+++ b/Makefile
@@ -34,5 +34,10 @@ test:
 .PHONY: build
 build: $(BIN)
 
+# Use this target to test packaging
+.PHONY: dist
+dist:
+	goreleaser release --skip-publish --skip-validate --rm-dist
+
 $(BIN): $(SOURCES)
 	$(GO) build $(GOFLAGS) -ldflags '-s -w $(LDFLAGS)' $(EXTRA_GOFLAGS) -o $@ ./cmd/$(BIN)


### PR DESCRIPTION
This PR improves a few details of the generated archives and Linux packages:

- archives are now in their own directory
- Windows archives are zip files
- deb and rpm contains more metadata and include the README.md and LICENSE files

I also added a `dist` Makefile target to make it easier to work on packaging.