### PR TITLE
chore(ci): publish deb and rpm packages on Cloudsmith

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,10 +13,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Install Cloudsmith CLI
+        run: pip install cloudsmith-cli==0.31.1
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -24,5 +29,9 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
+          # To publish the release on GitHub
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          # To publish on the Homebrew tap
           PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
+          # To publish on Cloudsmith
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,8 @@ builds:
     # Default build flags is `-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`.
 
 nfpms:
-  - formats:
+  - id: deb_rpm
+    formats:
       - deb
       - rpm
     dependencies:
@@ -70,3 +71,11 @@ brews:
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     folder: Formula
     description: "src-fingerprint is a CLI util to easily compute the fileshas associated to a set of git repositories."
+
+publishers:
+  - name: cloudsmith
+    ids:
+      - deb_rpm
+    cmd: "scripts/goreleaser-cloudsmith-publisher {{ .Version }} {{ abs .ArtifactPath }}"
+    env:
+      - CLOUDSMITH_API_KEY={{ .Env.CLOUDSMITH_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ brew tap gitguardian/tap
 brew install src-fingerprint
 ```
 
+### Linux packages
+
+Deb and RPM packages are available on [Cloudsmith](https://cloudsmith.io/~gitguardian/repos/src-fingerprint/packages/).
+
+Setup instructions:
+
+- [Deb packages](https://cloudsmith.io/~gitguardian/repos/src-fingerprint/setup/#formats-deb)
+- [RPM packages](https://cloudsmith.io/~gitguardian/repos/src-fingerprint/setup/#formats-rpm)
+
 ### From the sources
 
 You need `go` installed and `GOBIN` in your `PATH`. Once that is done, run the

--- a/scripts/goreleaser-cloudsmith-publisher
+++ b/scripts/goreleaser-cloudsmith-publisher
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+version="$1"
+artifact_path="$2"
+
+case "$artifact_path" in
+    *.deb)
+        cloudsmith push deb gitguardian/src-fingerprint/any-distro/any-version "$artifact_path"
+        ;;
+    *.rpm)
+        cloudsmith push rpm gitguardian/src-fingerprint/any-distro/any-version "$artifact_path"
+        ;;
+    *)
+        echo "Unsupported artifact format '$artifact_path'"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Description

This PR makes goreleaser publish the deb and rpm packages it produces on [Cloudsmith](https://cloudsmith.com/).

The test packages are available here: https://cloudsmith.io/~gitguardian/repos/src-fingerprint/packages/

## Testing

The release script was tested by running `goreleaser release --skip-validate --skip-announce --rm-dist` from a Docker, with a fake GitHub token. It uploaded the packages which are currently on Cloudsmith.

I tested the install process provided by Cloudsmith on Docker images (debian:stable and centos:latest) for amd64 binaries and in a Debian QEMU VM for arm64 binaries.

## Notes

This PR is a draft because it should not be merged until a `CLOUDSMITH_API_KEY` environment variable has been added to the repository configuration.