### PR TITLE
feat(user_extraction): we restrict extracted repos to owned repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Note that by default, `src-fingerprint` will exclude forked repositories from th
 env VCS_TOKEN="<token>" src-fingerprint -v --provider github --object ORG_NAME
 ```
 
-2. Export all fingerprints of every repository the user can access to the default path `./fingerprints.jsonl.gz`:
+2. Export all fingerprints of every repository the user owns to the default path `./fingerprints.jsonl.gz`:
+   **Important note :** For this usecase, you shall NOT use the `--object USERNAME` option, as this will indeed look for repos belonging to the user `USERNAME`, but without the authentication taken into account, hence omitting private repositories.
 
 ```sh
 env VCS_TOKEN="<token>" src-fingerprint -v --provider github --include-public-repos --include-forked-repos --include-archived-repos

--- a/provider/github.go
+++ b/provider/github.go
@@ -106,7 +106,8 @@ func (p *GitHubProvider) gatherPage(user string, page int) ([]GitRepository, err
 			ListOptions: github.ListOptions{
 				PerPage: reposPerPage, Page: page,
 			},
-			Visibility: visibility,
+			Visibility:  visibility,
+			Affiliation: "owner",
 		}
 
 		repos, resp, collectErr = p.client.Repositories.List(context.Background(), user, opt)


### PR DESCRIPTION
## Context
When a user runs src-fingerprint without any extra option, the tool will gather all repos that the user token has access to.  
In this issue, we limit this to repositories owned by the user. This is in order to avoid gathering undesired repositories for which the user would have been granted access.