### PR TITLE
Fix deletion of cloned repos

### DIFF
--- a/cloner/cloner.go
+++ b/cloner/cloner.go
@@ -35,6 +35,8 @@ func NewDiskCloner(baseDir string) *DiskCloner {
 
 			return diskCloner
 		}
+
+		log.Warnln("Clone directory provided does not exist. Will clone in default cache directory.")
 	}
 
 	if cacheDir, err := os.UserCacheDir(); err == nil {

--- a/extractor.go
+++ b/extractor.go
@@ -85,12 +85,14 @@ func (fe *FastExtractor) Run(path string, after string) chan *GitFile {
 			fe.ChanGitFiles <- &gitFile
 		}
 
-		close(fe.ChanGitFiles)
-		log.Infof("finishing iterating over files, we have collected %d files\n", num)
+		log.Infof("finished iterating over files, we have collected %d files\n", num)
 
 		if err := os.RemoveAll(path); err != nil {
 			log.Errorln("Unable to remove directory ", path)
 		}
+
+		log.Infof("Correctly removed cloned directory %s", path)
+		close(fe.ChanGitFiles)
 	}()
 
 	return fe.ChanGitFiles


### PR DESCRIPTION
In this MR, we fix the following bug :  
When collecting fingerprints for a set of repositories, some repositories were kept in the `--clone-dir` folder whereas they should have been deleted at the end of the process.  

To fix this :  
- First we added a log to clearly log when folders are deleted.
- We delayed the closing of the `gitFiles` channel in the `extractor`. Indeed, my suspicion is that closing this channel when manipulating the last repo analyzed causes the program execution to stop because the `eventChannel` becomes empty and can't be consumed anymore. Hence if we close the `gitFiles` early, the the last repo cloned was not removed in the end.  