### PR TITLE
fix(extractor): ignore lines that generate unmarshaling errors

### DIFF
--- a/extractor.go
+++ b/extractor.go
@@ -79,10 +79,11 @@ func (fe *FastExtractor) Run(path string, after string) chan *GitFile {
 
 			err := json.Unmarshal(cleanedLine, &gitFile)
 			if err != nil {
+				// If an error occurs, print a warning and do nothing with the line
 				log.Warnln("Error while parsing", string(line), err)
+			} else {
+				fe.ChanGitFiles <- &gitFile
 			}
-
-			fe.ChanGitFiles <- &gitFile
 		}
 
 		log.Infof("finished iterating over files, we have collected %d files\n", num)


### PR DESCRIPTION
In this PR, we handle behavior of the program if a line of the git command cannot be unmarshaled.  
To reproduce, you can try this command :  
```shell
env VCS_TOKEN=<TOKEN_HERE> ./src-fingerprint -v --provider repository --object "https://github.com/Linkedin/gobblin-elr"
```  

This repo will produce an error on one given fingerprint.  
- Before this PR : this ends up producing an "incorrect" line in the jsonl output. With empty type, size and sha.
- After this PR : the concerned fingerprint is ignored and is not part of the output anymore.

If you have ideas regarding why the error happens in the first place, this can be interesting, I did not find any obvious reason for this.