### PR TITLE
Add Windows install PowerShell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # src-fingerprint
 
-- [src-fingerprint](#src-fingerprint)
-  - [Introduction](#introduction)
-  - [Install](#install)
-  - [Generate My Token](#generate-my-token)
+- [Introduction](#introduction)
+- [Installation](#installation)
+	- [Using pre-compiled executables](#using-pre-compiled-executables)
+	- [Installing from sources](#installing-from-sources)
+- [Generate My Token](#generate-my-token)
     - [GitHub](#github)
     - [GitLab](#gitlab)
-  - [Compute my code fingerprints](#compute-my-code-fingerprints)
+- [Compute my code fingerprints](#compute-my-code-fingerprints)
     - [GitHub](#github-1)
     - [GitLab](#gitlab-1)
     - [Bitbucket server (formely Atlassian Stash)](#bitbucket-server-formely-atlassian-stash)
     - [Repository](#repository)
-  - [License](#License)
+- [License](#License)
 
 ## Introduction
 
@@ -23,22 +24,20 @@ This util supports 3 main version control systems:
 - Gitlab CE and EE
 - Bitbucket
 
-## Install
+## Installation
 
-### Pre-compiled executables
+### Using pre-compiled executables
 
-Get the executables [here](http://github.com/gitguardian/src-fingerprint/releases).
+#### macOS, using Homebrew
 
-### Using Homebrew
-
-If you're using [Homebrew](https://brew.sh/index_fr) you can add GitGuardian's tap and then install src-fingerprint. Just run the following commands :
+If you're using [Homebrew](https://brew.sh/index) you can add GitGuardian's tap and then install src-fingerprint. Just run the following commands:
 
 ```shell
 brew tap gitguardian/tap
 brew install src-fingerprint
 ```
 
-### Linux packages
+#### Linux packages
 
 Deb and RPM packages are available on [Cloudsmith](https://cloudsmith.io/~gitguardian/repos/src-fingerprint/packages/).
 
@@ -47,10 +46,31 @@ Setup instructions:
 - [Deb packages](https://cloudsmith.io/~gitguardian/repos/src-fingerprint/setup/#formats-deb)
 - [RPM packages](https://cloudsmith.io/~gitguardian/repos/src-fingerprint/setup/#formats-rpm)
 
-### From the sources
+#### Windows
 
-You need `go` installed and `GOBIN` in your `PATH`. Once that is done, run the
-command:
+Open a PowerShell prompt and run this command:
+
+```shell
+iwr -useb https://raw.githubusercontent.com/GitGuardian/src-fingerprint/main/scripts/windows-installer.ps1 | iex
+```
+
+The script asks for the installation directory. To install silently, use these commands instead:
+
+```shell
+iwr -useb https://raw.githubusercontent.com/GitGuardian/src-fingerprint/main/scripts/windows-installer.ps1 -Outfile install.ps1
+.\install.ps1 C:\Destination\Dir
+rm install.ps1
+```
+
+Note that `src-fingerprint` requires Unix commands such as `bash` to be available, so it runs better from a "Git Bash" prompt.
+
+#### Manual download
+
+You can also download the archives directly from the [releases page](http://github.com/gitguardian/src-fingerprint/releases).
+
+### Installing from sources
+
+You need `go` installed and `GOBIN` in your `PATH`. Once that is done, run the command:
 
 ```shell
 $ go get -u github.com/gitguardian/src-fingerprint/cmd/src-fingerprint

--- a/scripts/windows-installer.ps1
+++ b/scripts/windows-installer.ps1
@@ -1,0 +1,88 @@
+#Requires -Version 5
+param($install_dir)
+
+# This script can be used to download and install src-fingerprint on Windows,
+# from a PowerShell prompt. Refer to src-fingerprint README for more details.
+
+$DEFAULT_INSTALL_DIR = "$env:APPDATA\src-fingerprint"
+
+# Quit if anything goes wrong
+$old_erroractionpreference = $erroractionpreference
+$erroractionpreference = 'stop'
+
+if (($PSVersionTable.PSVersion.Major) -lt 5) {
+    Write-Output "PowerShell 5 or later is required to run this installer."
+    Write-Output "Upgrade PowerShell: https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell"
+    break
+}
+
+# Required to uncompress zip files
+Add-Type -Assembly "System.IO.Compression.FileSystem"
+
+function request_install_dir() {
+    $dir = Read-Host -Prompt "Installation dir [$DEFAULT_INSTALL_DIR]"
+    if ($dir -eq "") {
+        $dir = $DEFAULT_INSTALL_DIR
+    }
+    return $dir
+}
+
+function recreate_dir($dir) {
+    if (test-path $dir) {
+        Remove-Item $dir -Recurse -Force
+    }
+    mkdir $dir > $null
+}
+
+function download($url, $dst_file) {
+    $client = New-Object Net.Webclient
+    $client.DownloadFile($url, $dst_file)
+}
+
+function extract($zip_file, $dst_dir) {
+    [IO.Compression.ZipFile]::ExtractToDirectory($zip_file, $dst_dir)
+}
+
+function get_latest_version() {
+    $response = Invoke-RestMethod -Uri "https://api.github.com/repos/GitGuardian/src-fingerprint/releases/latest"
+    $tag = $response.tag_name
+    if ($tag.Length -lt 2 -or $tag[0] -ne "v") {
+        Write-Error -Category InvalidResult -Message "Invalid tag name: '$tag'"
+        exit
+    }
+    # $tag is "v1.2.3", we want "1.2.3"
+    $tag.SubString(1)
+}
+
+function main() {
+    if ($install_dir -eq $null) {
+        $install_dir = request_install_dir
+    }
+
+    $tmp_dir = "$install_dir\tmp"
+    recreate_dir $tmp_dir
+
+    Write-Output "Fetching version number of latest release"
+    $version = get_latest_version
+    Write-Output "Latest version is $version"
+
+    $zip_url = "https://github.com/GitGuardian/src-fingerprint/releases/download/v${version}/src-fingerprint_${version}_Windows_amd64.zip"
+
+    Write-Output "Downloading $zip_url"
+    $zip_file = "$tmp_dir\install.zip"
+    download $ZIP_URL $zip_file
+
+    Write-Output 'Extracting'
+    extract $zip_file $tmp_dir
+    Move-Item -Path "$tmp_dir\src-fingerprint_${VERSION}_Windows_*\*" -Destination $install_dir -Force
+
+    Write-Output 'Cleaning'
+    Remove-Item $tmp_dir -Recurse -Force
+
+    Write-Output "All done, src-fingerprint is now available at $install_dir\src-fingerprint.exe"
+}
+
+main
+
+# Reset $erroractionpreference to original value
+$erroractionpreference = $old_erroractionpreference


### PR DESCRIPTION
This PR adds a PowerShell script to install src-fingerprint on Windows.

It also refreshes a bit the install part of the README.

Some notes:
- The script installs in `C:\Users\<user>\AppData\Roaming\src-fingerprint` by default, because this directory does not require special user rights. Other apps, Chrome for example, do the same when running on unprivileged accounts.
- The link in the README won't work until the PR is merged, since it assumes downloading from the `main` branch. Replace `main` with `agateau/pdd-34/windows-install` to test.