### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,3 +37,29 @@ jobs:
         run: |
           go test -race $(go list ./...) -v -coverprofile=.coverage.out
           go tool cover -func=.coverage.out
+  integration-tests:
+    name: Integration Tests
+    runs-on: ${{ matrix.os }}
+    if: github.event_name == 'push'
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: go build -v -o . ./cmd/src-fingerprint
+
+      - name: Run Integration Tests
+        env:
+          GH_INTEGRATION_TESTS_TOKEN: ${{ secrets.GH_INTEGRATION_TESTS_TOKEN }}
+        run: |
+          python3 -m pip install pytest
+          pytest tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,0 @@
-include:
-  - project: "gg-code/sre/gitguardian-oss"
-    file: "/src-fingerprint.yml"

--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -90,7 +90,7 @@ func main() {
 	app := &cli.App{
 		Name:    "src-fingerprint",
 		Version: version,
-		Usage:   "Collect user/organization file hashes from your vcs provider of choice",
+		Usage:   "Collect user/organization source code fingerprints from your vcs provider of choice",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "verbose",
@@ -326,7 +326,7 @@ loop:
 
 	if fsOutput {
 		path, _ := filepath.Abs(c.String("output"))
-		fmt.Printf("Collected file hashes saved in file %s\n", path) // nolint
+		fmt.Printf("Collected fingerprints saved in file %s\n", path) // nolint
 	}
 
 	return nil

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,0 +1,184 @@
+import os
+import json
+import subprocess
+import pytest
+
+from typing import Set, Optional, List
+
+GH_INTEGRATION_TESTS_TOKEN = os.environ["GH_INTEGRATION_TESTS_TOKEN"]
+
+def run_src_fingerprint(provider: str, args: Optional[List[str]] = []):
+    subprocess.run(
+        [
+            "./src-fingerprint",
+            "-p",
+            provider,
+            "--token",
+            GH_INTEGRATION_TESTS_TOKEN,
+            "-f",
+            "jsonl",
+            "-o",
+            "fingerprints.jsonl"
+        ] + args,
+        check=True
+    )
+
+def load_jsonl(jsonl_path):
+    with open(jsonl_path) as f:
+        for line in f:
+            yield json.loads(line)
+
+def get_output_repos(output_path) -> Set[str]:
+    return {x["repository_name"] for x in load_jsonl(output_path)}
+
+
+def test_local_repository():
+    run_src_fingerprint(provider="repository", args=["--object", "."])
+    repos = get_output_repos("fingerprints.jsonl")
+    os.remove("fingerprints.jsonl")
+    assert len(repos) == 1
+
+
+@pytest.mark.parametrize(
+    "title, cmd_args, expected_output_repos", [
+        (
+            "Get all private repos accesible to user gg-src-fingerprint except archived ones",
+            [], 
+            {
+                # Repos for user gg-src-fingerprint
+                "main_private",
+                # Repos for org gg-src-fingerprint-org
+                "external_private",
+                "gg_src_fingerprint_private",
+            }
+        ),
+        (
+            "Get all private repos accesible to user gg-src-fingerprint",
+            ["--include-archived-repos"], 
+            {
+                # Repos for user gg-src-fingerprint
+                "main_private_archive",
+                "main_private",
+                # Repos for org gg-src-fingerprint-org
+                "gg_src_fingerprint_private",
+                "gg_src_fingerprint_private_archive",
+                "external_private",
+            }
+        ),
+        (
+            "Get all repos accesible to user gg-src-fingerprint except archived ones",
+            ["--include-public-repos", "--include-forked-repos"], 
+            {
+                # Repos for user gg-src-fingerprint
+                "main_private",
+                "main_public",
+                "src-fingerprint",
+                # Repos for org gg-src-fingerprint-org
+                "external_private",
+                "gg_src_fingerprint_private",
+                "gg_src_fingerprint_public",
+            }
+        ),
+        (
+            "Get all repos accesible to user gg-src-fingerprint except forked ones",
+            ["--include-public-repos", "--include-archived-repos"], 
+            {
+                # Repos for user gg-src-fingerprint
+                "main_archive",
+                "main_private",
+                "main_private_archive",
+                "main_public",
+                # Repos for org gg-src-fingerprint-org
+                "external_private",
+                "gg_src_fingerprint_private",
+                "gg_src_fingerprint_private_archive",
+                "gg_src_fingerprint_public",
+                "gg_src_fingerprint_public_archive",
+            }
+        ),
+                (
+            "Get all repos accesible to user gg-src-fingerprint",
+            ["--include-public-repos", "--include-archived-repos", "--include-forked-repos"], 
+            {
+                # Repos for user gg-src-fingerprint
+                "main_archive",
+                "main_private",
+                "main_private_archive",
+                "main_public",
+                "src-fingerprint",
+                # Repos for org gg-src-fingerprint-org
+                "external_private",
+                "gg_src_fingerprint_private",
+                "gg_src_fingerprint_private_archive",
+                "gg_src_fingerprint_public",
+                "gg_src_fingerprint_public_archive",
+            }
+        )
+    ]
+)
+def test_src_fingerprint_no_object_specified(title, cmd_args, expected_output_repos):
+    run_src_fingerprint(provider="github", args=cmd_args)
+    output_repos = get_output_repos("fingerprints.jsonl")
+    os.remove("fingerprints.jsonl")
+    assert output_repos == expected_output_repos
+
+
+@pytest.mark.parametrize(
+    "title, cmd_args, expected_output_repos", [
+        (
+            "Get all private repos except archived ones for org gg-src-fingerprint-org",
+            [], 
+            {
+                "gg_src_fingerprint_private",
+                "external_private"
+            }
+        ),
+        (
+            "Get all private repos for org gg-src-fingerprint-org",
+            ["--include-archived-repos"], 
+            {
+                "gg_src_fingerprint_private",
+                "gg_src_fingerprint_private_archive",
+                "external_private",
+            }
+        ),
+        (
+            "Get all repos for org gg-src-fingerprint-org except archived ones",
+            ["--include-public-repos", "--include-forked-repos"], 
+            {
+                "external_private",
+                "gg_src_fingerprint_private",
+                "gg_src_fingerprint_public",
+                "src-fingerprint",
+            }
+        ),
+        (
+            "Get all repos for org gg-src-fingerprint-org except forked ones",
+            ["--include-public-repos", "--include-archived-repos"], 
+            {
+                "external_private",
+                "gg_src_fingerprint_private",
+                "gg_src_fingerprint_private_archive",
+                "gg_src_fingerprint_public",
+                "gg_src_fingerprint_public_archive",
+            }
+        ),
+                (
+            "Get all repos for org gg-src-fingerprint-org",
+            ["--include-public-repos", "--include-archived-repos", "--include-forked-repos"], 
+            {
+                "external_private",
+                "gg_src_fingerprint_private",
+                "gg_src_fingerprint_private_archive",
+                "gg_src_fingerprint_public",
+                "gg_src_fingerprint_public_archive",
+                "src-fingerprint",
+            }
+        )
+    ]
+)
+def test_src_fingerprint_on_org(title, cmd_args, expected_output_repos):
+    run_src_fingerprint(provider="github", args=["--object", "gg-src-fingerprint-org"]+cmd_args)
+    output_repos = get_output_repos("fingerprints.jsonl")
+    os.remove("fingerprints.jsonl")
+    assert output_repos == expected_output_repos


### PR DESCRIPTION
In this MR, we do the following :  
1. Remove useless .gitlab-ci.yml file
2. Change wording from `file hashes` to `fingerprints`
3. Introduce python tests to test src-fingerprint end to end in the CI, here are some details hereunder.

- We created a user `gg-src-fingerprint` that has a bunch of repos : public, private, public archived, private archived and forked ones.
- We created an org [`gg-src-fingerprint-org`](https://github.com/gg-src-fingerprint-org) on which the user [`gg-src-fingerprint`](https://github.com/gg-src-fingerprint) created a bunch of repos in the same fashion with different types. Another user also created a private repo on the org, to test the case where `src-fingerprint` gathers all fingerprints of an org.
- The CI test runs on each push, and uses `gg-src-fingerprint` PAT to run `src-fingerprint`.  
- We run the test on three different runners to cover different platforms: Linux, MacOS and Windows.  

Note that this PR  is "external" and does not trigger the CI step, but if you want to see a succesful run [here is one](https://github.com/pierrelalanne/src-fingerprint/runs/5050054071?check_suite_focus=true).

**Remark :** This tests are intended to run in the CI only to make sure that modifications brought to `src-fingerprint` do not break its core features.