### PR TITLE
feat(provider): Repository provider infers the repo name when omitted

### DIFF
--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -33,10 +33,11 @@ def get_output_repos(output_path) -> Set[str]:
 
 
 def test_local_repository():
-    run_src_fingerprint(provider="repository", args=["--object", "."])
+    run_src_fingerprint(provider="repository", args=["--object", "../src-fingerprint"])
     repos = get_output_repos("fingerprints.jsonl")
     os.remove("fingerprints.jsonl")
     assert len(repos) == 1
+    assert repos == {"src-fingerprint"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
With the `repository` provider, if the name of the repository is omitted, it will be infer from the URL/path. 

Now, `src-fingerprint --provider repository --object "https://github.com/GitGuardian/src-fingerprint"` will produce:
```json
{
  "repository_name": "src-fingerprint",
  "private": false,
  "sha": "a0c16efce5e767f04ba0c6988d121147099a17df",
  "type": "blob",
  "filepath": ".env.example",
  "size": "31"
}
...
```

closes https://github.com/GitGuardian/src-fingerprint/issues/26