### PR TITLE
Improve the inference of the repository name by the repository provider

### DIFF
--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -99,6 +99,11 @@ func main() {
 				Usage:   "verbose logging",
 			},
 			&cli.BoolFlag{
+				Name:  "debug",
+				Value: false,
+				Usage: "debug logging, override verbose",
+			},
+			&cli.BoolFlag{
 				Name:  "include-forked-repos",
 				Value: false,
 				Usage: "include forked repositories. Available for 'github' and 'gitlab' providers.",
@@ -185,7 +190,9 @@ func main() {
 }
 
 func mainAction(c *cli.Context) error {
-	if c.Bool("verbose") {
+	if c.Bool("debug") {
+		log.SetLevel(log.DebugLevel)
+	} else if c.Bool("verbose") {
 		log.SetLevel(log.InfoLevel)
 	} else {
 		log.SetLevel(log.WarnLevel)


### PR DESCRIPTION
Following #44 

- Improve the inference of the repository name by the repository provider by using the absolute path when the target is a path.
- Add a flag to see the debug-logging logs
     - It would have helped with #40 because the logs are:
    
```
time="2022-02-08T17:26:13+01:00" level=debug msg="parsing line {\"sha\": \"67ffd75100bd8d4dd237734e6618530cef13dfee\", \"type\": \"blob\", \"filepath\": \
"gobblin-core/src/main/java/gobblin/converter/avro/test\x10.schema\", \"size\": \"5388\"}"
time="2022-02-08T17:26:13+01:00" level=warning msg="Error while parsing {\"sha\": \"67ffd75100bd8d4dd237734e6618530cef13dfee\", \"type\": \"blob\", \"filepath\": \"gobblin-core/src/main/java/gobblin/converter/avro/test\x10.schema\", \"size\": \"5388\"} invalid character '\\x10' in string literal"
```

We can see the character `x10` in the filepath.