### PR TITLE
Add subcommand to the CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,8 @@ It reads from CLI and environment the configuration and run the Pipeline on an o
 
 - Run on a given user/group
   ```sh
-  ./src-fingerprint --provider github --object Uber
-  ./src-fingerprint --provider-url http://gitlab.example.com --provider gitlab --object Groupe
+  ./src-fingerprint collect --provider github --object Uber
+  ./src-fingerprint collect --provider-url http://gitlab.example.com --provider gitlab --object Groupe
   ```
 
 ## Performance considerations

--- a/README.md
+++ b/README.md
@@ -2,23 +2,23 @@
 
 - [Introduction](#introduction)
 - [Installation](#installation)
-	- [Using pre-compiled executables](#using-pre-compiled-executables)
-	- [Installing from sources](#installing-from-sources)
+  - [Using pre-compiled executables](#using-pre-compiled-executables)
+  - [Installing from sources](#installing-from-sources)
 - [Generate My Token](#generate-my-token)
-    - [GitHub](#github)
-    - [GitLab](#gitlab)
+  - [GitHub](#github)
+  - [GitLab](#gitlab)
 - [Compute my code fingerprints](#compute-my-code-fingerprints)
-    - [GitHub](#github-1)
-    - [GitLab](#gitlab-1)
-    - [Bitbucket server (formely Atlassian Stash)](#bitbucket-server-formely-atlassian-stash)
-    - [Repository](#repository)
+  - [GitHub](#github-1)
+  - [GitLab](#gitlab-1)
+  - [Bitbucket server (formely Atlassian Stash)](#bitbucket-server-formely-atlassian-stash)
+  - [Repository](#repository)
 - [License](#License)
 
 ## Introduction
 
 The purpose of `src-fingerprint` is to provide an easy way to extract git related information (namely all file shas of a repository) from your hosted source version control system.
 
-This util supports 3 main version control systems:
+This util's main command is the `collect` command used to collect source code fingerprints from a version control system or a local repository. It supports 3 main VCS:
 
 - GitHub and GitHub Enterprise
 - Gitlab CE and EE
@@ -94,7 +94,7 @@ $ go get -u github.com/gitguardian/src-fingerprint/cmd/src-fingerprint
 3. Click the `read repository` box. This is the only scope we need. You can set an end-date for the token validity if you want more security
 4. Click on `Create personal token`. The token will only be available at this time so make sure you keep it in a safe place
 
-## Compute my code fingerprints
+## Collect my code fingerprints
 
 ### General information
 
@@ -171,31 +171,31 @@ Allows the processing of a single repository given a git clone URL
 1. ssh cloning
 
 ```sh
-src-fingerprint -p repository -u 'git@github.com:GitGuardian/gg-shield.git'
+src-fingerprint collect -p repository -u 'git@github.com:GitGuardian/gg-shield.git'
 ```
 
 2. http cloning with basic authentication
 
 ```sh
-src-fingerprint -p repository -u 'https://user:password@github.com/GitGuardian/gg-shield.git'
+src-fingerprint collect -p repository -u 'https://user:password@github.com/GitGuardian/gg-shield.git'
 ```
 
 2. http cloning without basic authentication
 
 ```sh
-src-fingerprint -p repository -u 'https://github.com/GitGuardian/gg-shield.git'
+src-fingerprint collect -p repository -u 'https://github.com/GitGuardian/gg-shield.git'
 ```
 
 3. repository in a local directory
 
 ```sh
-src-fingerprint -p repository -u /projects/gitlab/src-fingerprint
+src-fingerprint collect -p repository -u /projects/gitlab/src-fingerprint
 ```
 
 4. repository in current directory
 
 ```sh
-src-fingerprint -p repository -u .
+src-fingerprint collect -p repository -u .
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ Note that by default, `src-fingerprint` will exclude forked repositories from th
 1. Export all fingerprints from private repositories from a GitHub Org to the default path `./fingerprints.jsonl.gz` with logs:
 
 ```sh
-env VCS_TOKEN="<token>" src-fingerprint -v --provider github --object ORG_NAME
+env VCS_TOKEN="<token>" src-fingerprint -v collect --provider github --object ORG_NAME
 ```
 
 2. Export all fingerprints of every repository the user can access to the default path `./fingerprints.jsonl.gz`:
 
 ```sh
-env VCS_TOKEN="<token>" src-fingerprint -v --provider github --include-public-repos --include-forked-repos --include-archived-repos
+env VCS_TOKEN="<token>" src-fingerprint -v collect --provider github --include-public-repos --include-forked-repos --include-archived-repos
 ```
 
 ### GitLab
@@ -141,13 +141,13 @@ env VCS_TOKEN="<token>" src-fingerprint -v --provider github --include-public-re
 1. Export all fingerprints from private repositories of a GitLab group to the default path `./fingerprints.jsonl.gz` with logs:
 
 ```sh
-env VCS_TOKEN="<token>" src-fingerprint -v --provider gitlab --object "GitGuardian-dev-group"
+env VCS_TOKEN="<token>" src-fingerprint -v collect --provider gitlab --object "GitGuardian-dev-group"
 ```
 
 2. Export all fingerprints of every project the user can access to the default path `./fingerprints.jsonl.gz` with logs:
 
 ```sh
-env VCS_TOKEN="<token>" src-fingerprint -v --provider gitlab --include-forked-repos
+env VCS_TOKEN="<token>" src-fingerprint -v collect --provider gitlab --include-forked-repos
 ```
 
 ### Bitbucket server (formely Atlassian Stash)
@@ -155,13 +155,13 @@ env VCS_TOKEN="<token>" src-fingerprint -v --provider gitlab --include-forked-re
 1. Export all fingerprints from a Bitbucket project with private repository to the default path `./fingerprints.jsonl.gz` with logs:
 
 ```sh
-env VCS_TOKEN="<token>" src-fingerprint -v --provider bitbucket --object "GitGuardian Project"
+env VCS_TOKEN="<token>" src-fingerprint -v collect --provider bitbucket --object "GitGuardian Project"
 ```
 
 2. Export all fingerprints of every repository the user can access to the default path `./fingerprints.jsonl.gz` with logs:
 
 ```sh
-env VCS_TOKEN="<token>" src-fingerprint -v --provider bitbucket
+env VCS_TOKEN="<token>" src-fingerprint -v collect --provider bitbucket
 ```
 
 ### Repository

--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -90,98 +90,109 @@ func main() {
 	app := &cli.App{
 		Name:    "src-fingerprint",
 		Version: version,
-		Usage:   "Collect user/organization source code fingerprints from your vcs provider of choice",
-		Flags: []cli.Flag{
-			&cli.BoolFlag{
-				Name:    "verbose",
-				Aliases: []string{"v"},
-				Value:   false,
-				Usage:   "verbose logging",
-			},
-			&cli.BoolFlag{
-				Name:  "debug",
-				Value: false,
-				Usage: "debug logging, override verbose",
-			},
-			&cli.BoolFlag{
-				Name:  "include-forked-repos",
-				Value: false,
-				Usage: "include forked repositories. Available for 'github' and 'gitlab' providers.",
-			},
-			&cli.BoolFlag{
-				Name:  "include-public-repos",
-				Value: false,
-				Usage: "Include fileshas from both public and private repositories. Available for 'github' provider only.",
-			},
-			&cli.BoolFlag{
-				Name:  "include-archived-repos",
-				Value: false,
-				Usage: "Include archived repositories. Available for 'github' provider only.",
-			},
-			&cli.StringFlag{
-				Name:    "output",
-				Aliases: []string{"o"},
-				Value:   "./fingerprints.jsonl.gz",
-				Usage:   "set output path to `FILE`. Use \"-\" to redirect to stdout.",
-			},
-			&cli.StringFlag{
-				Name:    "export-format",
-				Aliases: []string{"f"},
-				Value:   "gzip-jsonl",
-				Usage:   "export format: 'jsonl'/'gzip-jsonl'/'json'/'gzip-json'",
-			},
-			&cli.StringFlag{
-				Name:  "clone-dir",
-				Value: "-",
-				Usage: "set cloning location for repositories",
-			},
-			&cli.StringFlag{
-				Name:  "after",
-				Value: "",
-				Usage: "set a commit date after which we want to collect fileshas",
-			},
-			&cli.StringFlag{
-				Name:     "provider",
-				Aliases:  []string{"p"},
-				Required: true,
-				Usage:    "vcs provider. options: 'gitlab'/'github'/'bitbucket'/'repository'",
-			},
-			&cli.StringFlag{
-				Name:  "repo-name",
-				Usage: "Name of the repository to display in outputs if the provider is 'repository'",
-			},
-			&cli.BoolFlag{
-				Name:  "repo-is-private",
-				Value: false,
-				Usage: "Private status value to display in outputs if the provider is 'repository'",
-			},
-			&cli.StringFlag{
-				Name:    "token",
-				Aliases: []string{"t"},
-				Usage:   "token for vcs access.",
-				EnvVars: []string{"VCS_TOKEN", "GITLAB_TOKEN", "GITHUB_TOKEN"},
-			},
-			&cli.StringFlag{
-				Name:    "object",
-				Aliases: []string{"u"},
-				Usage:   "repository|org|group to scrape. If not specified all reachable repositories will be collected.",
-			},
-			&cli.IntFlag{
-				Name:  "cloners",
-				Value: DefaultClonerN,
-				Usage: "number of cloners, more cloners means more memory usage",
-			},
-			&cli.StringFlag{
-				Name:  "provider-url",
-				Usage: "base URL of the Git provider API. If not set, defaults URL are used.",
-			},
-			&cli.IntFlag{
-				Name:  "limit",
-				Value: DefaultLimit,
-				Usage: "maximum number of repositories to analyze (0 for unlimited).",
+		Usage:   "src-fingerprint is a tool to collect and manipulate source code fingerprints.",
+		Commands: []*cli.Command{
+			{
+				Name:   "collect",
+				Usage:  "Collect user or organization source code fingerprints from a vcs provider or from a local repository.",
+				Action: collectAction,
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     "provider",
+						Aliases:  []string{"p"},
+						Required: true,
+						Usage:    "Source code provider. options: 'gitlab'/'github'/'bitbucket'/'repository'",
+					},
+					&cli.StringFlag{
+						Name:  "provider-url",
+						Usage: "base URL of the Git provider API. If not set, defaults URL are used.",
+					},
+					&cli.StringFlag{
+						Name:    "object",
+						Aliases: []string{"u"},
+						Usage:   "repository|org|group to scrape. If not specified all reachable repositories will be collected.",
+					},
+					&cli.BoolFlag{
+						Name:    "verbose",
+						Aliases: []string{"v"},
+						Value:   false,
+						Usage:   "Run with verbose logging",
+					},
+					&cli.BoolFlag{
+						Name:  "debug",
+						Value: false,
+						Usage: "debug logging, override verbose",
+					},
+					&cli.BoolFlag{
+						Name:  "debug",
+						Value: false,
+						Usage: "Run with debug logging, overrides verbose",
+					},
+					&cli.BoolFlag{
+						Name:  "include-forked-repos",
+						Value: false,
+						Usage: "include forked repositories. Available for 'github' and 'gitlab' providers.",
+					},
+					&cli.BoolFlag{
+						Name:  "include-public-repos",
+						Value: false,
+						Usage: "Include fileshas from both public and private repositories. Available for 'github' provider only.",
+					},
+					&cli.BoolFlag{
+						Name:  "include-archived-repos",
+						Value: false,
+						Usage: "Include archived repositories. Available for 'github' provider only.",
+					},
+					&cli.StringFlag{
+						Name:    "export-format",
+						Aliases: []string{"f"},
+						Value:   "gzip-jsonl",
+						Usage:   "export format: 'jsonl'/'gzip-jsonl'/'json'/'gzip-json'",
+					},
+					&cli.StringFlag{
+						Name:    "output",
+						Aliases: []string{"o"},
+						Value:   "./fingerprints.jsonl.gz",
+						Usage:   "set output path to `FILE`. Use \"-\" to redirect to stdout.",
+					},
+					&cli.StringFlag{
+						Name:  "clone-dir",
+						Value: "-",
+						Usage: "set cloning location for repositories",
+					},
+					&cli.StringFlag{
+						Name:  "after",
+						Value: "",
+						Usage: "set a commit date after which we want to collect fileshas",
+					},
+					&cli.StringFlag{
+						Name:  "repo-name",
+						Usage: "Name of the repository to display in outputs if the provider is 'repository'",
+					},
+					&cli.BoolFlag{
+						Name:  "repo-is-private",
+						Value: false,
+						Usage: "Private status value to display in outputs if the provider is 'repository'",
+					},
+					&cli.StringFlag{
+						Name:    "token",
+						Aliases: []string{"t"},
+						Usage:   "token for vcs access.",
+						EnvVars: []string{"VCS_TOKEN", "GITLAB_TOKEN", "GITHUB_TOKEN"},
+					},
+					&cli.IntFlag{
+						Name:  "cloners",
+						Value: DefaultClonerN,
+						Usage: "number of cloners, more cloners means more memory usage",
+					},
+					&cli.IntFlag{
+						Name:  "limit",
+						Value: DefaultLimit,
+						Usage: "maximum number of repositories to analyze (0 for unlimited).",
+					},
+				},
 			},
 		},
-		Action: mainAction,
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -189,7 +200,7 @@ func main() {
 	}
 }
 
-func mainAction(c *cli.Context) error {
+func collectAction(c *cli.Context) error {
 	if c.Bool("debug") {
 		log.SetLevel(log.DebugLevel)
 	} else if c.Bool("verbose") {

--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -91,6 +91,20 @@ func main() {
 		Name:    "src-fingerprint",
 		Version: version,
 		Usage:   "src-fingerprint is a tool to collect and manipulate source code fingerprints.",
+		Before:  beforeAction,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:    "verbose",
+				Aliases: []string{"v"},
+				Value:   false,
+				Usage:   "Run with verbose logging",
+			},
+			&cli.BoolFlag{
+				Name:  "debug",
+				Value: false,
+				Usage: "Run with debug logging, override verbose",
+			},
+		},
 		Commands: []*cli.Command{
 			{
 				Name:   "collect",
@@ -111,22 +125,6 @@ func main() {
 						Name:    "object",
 						Aliases: []string{"u"},
 						Usage:   "repository|org|group to scrape. If not specified all reachable repositories will be collected.",
-					},
-					&cli.BoolFlag{
-						Name:    "verbose",
-						Aliases: []string{"v"},
-						Value:   false,
-						Usage:   "Run with verbose logging",
-					},
-					&cli.BoolFlag{
-						Name:  "debug",
-						Value: false,
-						Usage: "debug logging, override verbose",
-					},
-					&cli.BoolFlag{
-						Name:  "debug",
-						Value: false,
-						Usage: "Run with debug logging, overrides verbose",
 					},
 					&cli.BoolFlag{
 						Name:  "include-forked-repos",
@@ -200,7 +198,7 @@ func main() {
 	}
 }
 
-func collectAction(c *cli.Context) error {
+func beforeAction(c *cli.Context) error {
 	if c.Bool("debug") {
 		log.SetLevel(log.DebugLevel)
 	} else if c.Bool("verbose") {
@@ -209,6 +207,10 @@ func collectAction(c *cli.Context) error {
 		log.SetLevel(log.WarnLevel)
 	}
 
+	return nil
+}
+
+func collectAction(c *cli.Context) error {
 	output := os.Stdout
 	fsOutput := false
 

--- a/provider/generic_repository.go
+++ b/provider/generic_repository.go
@@ -51,7 +51,7 @@ func (p *GenericProvider) Gather(user string) ([]GitRepository, error) {
 	if user == "" {
 		return nil, errors.New(
 			"this provider requires an object. " +
-				"Example: src-fingerprint -p repository -u 'https://github.com/GitGuardian/src-fingerprint'",
+				"Example: src-fingerprint collect -p repository -u 'https://github.com/GitGuardian/src-fingerprint'",
 		)
 	}
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -11,6 +11,7 @@ def run_src_fingerprint(provider: str, args: Optional[List[str]] = []):
     subprocess.run(
         [
             "./src-fingerprint",
+            "collect",
             "-p",
             provider,
             "--token",


### PR DESCRIPTION
In this PR, we re-organize the CLI to allow subcommands, this is in order to be prepared for any future development if the util is meant to do more than collecting fingerprints.  

What we have done :  
- Add a subcommand in the CLI
- Modify README accordingly
- Modify comment mentioning commands
- Modify tests to use this command