### PR TITLE
Add integration tests bitbucket

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,8 @@ jobs:
       - name: Run Integration Tests
         env:
           GH_INTEGRATION_TESTS_TOKEN: ${{ secrets.GH_INTEGRATION_TESTS_TOKEN }}
+          BITBUCKET_INTEGRATION_TESTS_TOKEN: ${{ secrets.BITBUCKET_INTEGRATION_TESTS_TOKEN }}
+          BITBUCKET_INTEGRATION_TESTS_URL: ${{ secrets.BITBUCKET_INTEGRATION_TESTS_URL }}
         run: |
           python3 -m pip install pytest
           pytest tests

--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -328,13 +328,13 @@ loop:
 				continue
 			}
 
-			log.Infof("%v/%v repos: %v files analyzed\n",
+			log.Infof("Repository %v/%v: %v files analyzed\n",
 				doneRepo, totalRepo, gitFilesCount)
 		}
 	}
 
 	log.Infoln("Final stats:")
-	log.Infof("%v/%v repos: %v files analyzed\n",
+	log.Infof("Repository %v/%v: %v files analyzed\n",
 		doneRepo, totalRepo, gitFilesCount)
 	log.Infof("Dumping to output %v\n", c.String("output"))
 

--- a/extractor.go
+++ b/extractor.go
@@ -86,7 +86,7 @@ func (fe *FastExtractor) Run(path string, after string) chan *GitFile {
 			}
 		}
 
-		log.Infof("finished iterating over files, we have collected %d files\n", num)
+		log.Infof("finished iterating over files, %d file(s) collected.\n", num)
 
 		if err := os.RemoveAll(path); err != nil {
 			log.Errorln("Unable to remove directory ", path)

--- a/provider/bitbucket.go
+++ b/provider/bitbucket.go
@@ -112,13 +112,13 @@ func NewBitbucketProvider(token string, options Options) Provider {
 	return &BitbucketProvider{client: client, options: options, token: token, transport: transport}
 }
 
-func (p *BitbucketProvider) gatherPage(start int, project string) ([]GitRepository, int, error) {
+func (p *BitbucketProvider) gatherRepos(start int, project string) ([]GitRepository, int, error) {
 	opt := &bitbucket.ListRepositoriesOptions{ListOptions: bitbucket.ListOptions{Start: start, Limit: reposPerPage}}
 	if project != "" {
 		opt.ProjectName = project
 	}
 
-	log.Infof("Gathering page %v\n", start)
+	log.Infof("Gathering repos %v -> %v\n", start, start+reposPerPage)
 
 	repos, resp, err := p.client.Repositories.List(context.Background(), opt)
 	if err != nil {
@@ -150,7 +150,7 @@ func (p *BitbucketProvider) collect(
 
 		var pageRepositories []GitRepository
 
-		pageRepositories, start, err = p.gatherPage(start, project)
+		pageRepositories, start, err = p.gatherRepos(start, project)
 		if err != nil {
 			log.Errorf("Error gathering start %v:%v\n", start, err)
 


### PR DESCRIPTION
In this PR :  
- we add integration tests for BitBucket
- we clean some logging

Secrets were added to the repo as well.

A successful run of the CI pipeline can be found [here](https://github.com/pierrelalanne/src-fingerprint/runs/5364545846).