### PR TITLE
feat(cli): Accept multiple --object flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The default format is `gzip-jsonl` to minimize the size of the output file.
 The default output filepath is `./fingerprints.jsonl.gz`. Use `--output` to override this behavior.  
 Also, note that if you were to download fingerprints for repositories of a big organization, `src-fingerprint` has a limit to process no more than 100
 repositories. You can override this limit with the option `--limit`, a limit of 0 will process all repos of the organization.
+Note that if multiple organizations are passed, the limit is applied to each one independently.
 
 ### Sample output
 
@@ -126,10 +127,10 @@ For all the following examples, we assume that the user is able to clone reposit
 
 ### GitHub
 
-1. Export all fingerprints from private repositories from a GitHub Org to the default path `./fingerprints.jsonl.gz` with logs:
+1. Export all fingerprints from private repositories from GitHub Orgs to the default path `./fingerprints.jsonl.gz` with logs:
 
 ```sh
-env VCS_TOKEN="<token>" src-fingerprint -v collect --provider github --object ORG_NAME
+env VCS_TOKEN="<token>" src-fingerprint -v collect --provider github --object ORG_1_NAME --object ORG_2_NAME
 ```
 
 2. Export all fingerprints of every repository the user can access to the default path `./fingerprints.jsonl.gz`:
@@ -153,7 +154,7 @@ env VCS_TOKEN="<token>" src-fingerprint -v collect --provider gitlab --object "G
 env VCS_TOKEN="<token>" src-fingerprint -v collect --provider gitlab --include-forked-repos
 ```
 
-### Bitbucket server (formely Atlassian Stash)
+### Bitbucket server (formerly Atlassian Stash)
 
 1. Export all fingerprints from a Bitbucket project with private repository to the default path `./fingerprints.jsonl.gz` with logs:  
    **Note :** If you are targeting a self-hosted BitBucket instance, use the `--provider-url` to specify its url, don't forget to include the scheme.
@@ -190,10 +191,10 @@ src-fingerprint collect -p repository -u 'https://user:password@github.com/GitGu
 src-fingerprint collect -p repository -u 'https://github.com/GitGuardian/gg-shield.git'
 ```
 
-3. repository in a local directory
+3. repository in multiple local directories
 
 ```sh
-src-fingerprint collect -p repository -u /projects/gitlab/src-fingerprint
+src-fingerprint collect -p repository -u /projects/gitlab/src-fingerprint -u /projects/gitlab/internal-api
 ```
 
 4. repository in current directory

--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -118,21 +118,22 @@ func main() {
 						Name:     "provider",
 						Aliases:  []string{"p"},
 						Required: true,
-						Usage:    "Source code provider. options: 'gitlab'/'github'/'bitbucket'/'repository'",
+						Usage:    "Source code provider. options: 'gitlab'/'github'/'bitbucket'/'repository'.",
 					},
 					&cli.StringFlag{
 						Name:  "provider-url",
-						Usage: "base URL of the Git provider API. If not set, defaults URL are used.",
+						Usage: "Base URL of the Git provider API. If not set, defaults URL are used.",
 					},
 					&cli.StringSliceFlag{
 						Name:    "object",
 						Aliases: []string{"u"},
-						Usage:   "repository|org|group to scrape. If not specified all reachable repositories will be collected.",
+						Usage: "Repository, organization or group to scrape. If not specified all reachable " +
+							"repositories will be collected.",
 					},
 					&cli.BoolFlag{
 						Name:  "include-forked-repos",
 						Value: false,
-						Usage: "include forked repositories. Available for 'github' and 'gitlab' providers.",
+						Usage: "Include forked repositories. Available for 'github' and 'gitlab' providers.",
 					},
 					&cli.BoolFlag{
 						Name:  "include-public-repos",
@@ -148,18 +149,18 @@ func main() {
 						Name:    "export-format",
 						Aliases: []string{"f"},
 						Value:   "gzip-jsonl",
-						Usage:   "export format: 'jsonl'/'gzip-jsonl'/'json'/'gzip-json'",
+						Usage:   "Export format: 'jsonl'/'gzip-jsonl'/'json'/'gzip-json'.",
 					},
 					&cli.StringFlag{
 						Name:    "output",
 						Aliases: []string{"o"},
 						Value:   "./fingerprints.jsonl.gz",
-						Usage:   "set output path to `FILE`. Use \"-\" to redirect to stdout.",
+						Usage:   "Set output path to `FILE`. Use \"-\" to redirect to stdout.",
 					},
 					&cli.StringFlag{
 						Name:  "clone-dir",
 						Value: "-",
-						Usage: "set cloning location for repositories",
+						Usage: "Set cloning location for repositories.",
 					},
 					&cli.BoolFlag{
 						Name:  "ssh-cloning",
@@ -169,32 +170,33 @@ func main() {
 					&cli.StringFlag{
 						Name:  "after",
 						Value: "",
-						Usage: "set a commit date after which we want to collect fileshas",
+						Usage: "Set a commit date after which we want to collect fileshas.",
 					},
 					&cli.StringFlag{
 						Name:  "repo-name",
-						Usage: "Name of the repository to display in outputs if the provider is 'repository'",
+						Usage: "Name of the repository to display in outputs if the provider is 'repository'.",
 					},
 					&cli.BoolFlag{
 						Name:  "repo-is-private",
 						Value: false,
-						Usage: "Private status value to display in outputs if the provider is 'repository'",
+						Usage: "Private status value to display in outputs if the provider is 'repository'.",
 					},
 					&cli.StringFlag{
 						Name:    "token",
 						Aliases: []string{"t"},
-						Usage:   "token for vcs access.",
+						Usage:   "Token for vcs access.",
 						EnvVars: []string{"VCS_TOKEN", "GITLAB_TOKEN", "GITHUB_TOKEN"},
 					},
 					&cli.IntFlag{
 						Name:  "cloners",
 						Value: DefaultClonerN,
-						Usage: "number of cloners, more cloners means more memory usage",
+						Usage: "Number of cloners, more cloners means more memory usage.",
 					},
 					&cli.IntFlag{
 						Name:  "limit",
 						Value: DefaultLimit,
-						Usage: "maximum number of repositories to analyze (0 for unlimited).",
+						Usage: "Maximum number of repositories to analyze (0 for unlimited). " +
+							"The limit is applied for independently to each object.",
 					},
 				},
 			},


### PR DESCRIPTION
closes #61 

This PR allows to pass multiple `--object/-u` flags to the CLI. This is the quick way to implement it, I've edited less than 10 lines of code, but `--limit` will be applied separately to each object. Meaning a command with `-u org1 -u org2 --limit 10` will return up to 20 repositories.

If this behavior is acceptable, it allows to close #61 quickly. Otherwise, we can close this PR.