### PR TITLE
Run the extraction of multiple objects in a pool of goroutines

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,7 @@ nfpms:
       - rpm
     dependencies:
       - git
+      - procps
     bindir: /usr/bin
     vendor: GitGuardian
     maintainer: GitGuardian <dev@gitguardian.com>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [GitLab](#gitlab-1)
   - [Bitbucket server (formely Atlassian Stash)](#bitbucket-server-formely-atlassian-stash)
   - [Repository](#repository)
+- [Performance](#performance-and-memory-usage)
 - [License](#License)
 
 ## Introduction
@@ -203,6 +204,15 @@ src-fingerprint collect -p repository -u /projects/gitlab/src-fingerprint -u /pr
 ```sh
 src-fingerprint collect -p repository -u .
 ```
+
+### Performance and memory usage
+
+`src-fingerprint` will by default process each object (`--object`/`-u`) one by one. When an object (ie: a GitHub Organization)
+contains multiple repositories, they are processed in parallel by multiple cloners, the number of cloners is configurable 
+with `--cloners`. Adding more cloners will increase the memory usage of `src-fingerprint`. When extracting fingerprints
+from multiple sources (e.g. with multiple --object values), you can use the option `--pool` to configure the number of 
+workers that will process the objects in parallel. Each worker will have `--cloners` cloners. Be cautious when increasing 
+both `--cloners` and `--pool`, the memory usage may increase drastically.
 
 ## License
 

--- a/cmd/src-fingerprint/run_extract.go
+++ b/cmd/src-fingerprint/run_extract.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"srcfingerprint"
+	"sync"
+	"time"
+
+	"github.com/Jeffail/tunny"
+	log "github.com/sirupsen/logrus"
+)
+
+type PoolPayload struct {
+	object       string
+	eventChannel chan srcfingerprint.PipelineEvent
+	waitGroup    *sync.WaitGroup
+}
+
+// Run the extraction in separate goroutine for each objects using a pool of size poolSize.
+func runExtract(
+	pipeline *srcfingerprint.Pipeline,
+	objects []string,
+	after string,
+	limit int,
+	timeout time.Duration,
+	poolSize int) chan srcfingerprint.PipelineEvent {
+	// If there is no object, default to an empty object
+	if len(objects) == 0 {
+		objects = []string{""}
+	}
+
+	eventChannel := make(chan srcfingerprint.PipelineEvent, MaxPipelineEvents)
+
+	wg := sync.WaitGroup{}
+	pool := tunny.NewFunc(poolSize, func(rawPayload interface{}) interface{} {
+		payload, ok := rawPayload.(PoolPayload)
+		if !ok {
+			// Impossible error, pool is only used with PoolPayload structs
+			log.Fatal("Could not load the payload to run the extraction")
+		}
+
+		defer payload.waitGroup.Done()
+		pipeline.ExtractRepositories(payload.object, after, payload.eventChannel, limit, timeout)
+
+		return nil
+	})
+
+	for _, object := range objects {
+		wg.Add(1)
+
+		go pool.Process(PoolPayload{object: object, eventChannel: eventChannel, waitGroup: &wg})
+	}
+
+	go func() {
+		// Wait for every worker and close pipelineChannel
+		wg.Wait()
+		close(eventChannel)
+	}()
+
+	return eventChannel
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module srcfingerprint
 go 1.16
 
 require (
+	github.com/Jeffail/tunny v0.1.4 // indirect
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Jeffail/tunny v0.1.4 h1:chtpdz+nUtaYQeCKlNBg6GycFF/kGVHOr6A3cmzTJXs=
+github.com/Jeffail/tunny v0.1.4/go.mod h1:P8xAx4XQl0xsuhjX1DtfaMDCSuavzdb2rwbd0lk+fvo=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXGjwU=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=


### PR DESCRIPTION
Using [tunny](github.com/Jeffail/tunny), this PR makes `src-fingerprint` execute the extraction of multiple objects in a pool of goroutines. This size of the pool is controlled by the new argument `--pool`, by default the behavior of `src-fingerprint` stays the same and the size of the pool is 1.

I've also included a small fix for unix builds, by adding `procps` as a dependency for the deb/rpm release.